### PR TITLE
Discarding the master/slave lingo

### DIFF
--- a/mail2web.py
+++ b/mail2web.py
@@ -496,7 +496,7 @@ def send_mail(command_id, command_raw, payload, rec):
     msg['From'] =  Opts['sender']
     msg['To'] = rec
     # Plain text as explanation
-    explanation = "This is the demon slave\n" + \
+    explanation = "This is the demon subordinate\n" + \
                    "I executed for you:\n" + command_raw + \
                    "\n\nHave fun!\n" + \
                    "To reach some admin, please mailto: admin@thishost\n" + \


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.